### PR TITLE
Change Intel oneAPI to 2022.1.2 by default

### DIFF
--- a/apps/gromacs/README.md
+++ b/apps/gromacs/README.md
@@ -90,7 +90,7 @@ export AWS_REGION=`curl --silent http://169.254.169.254/latest/meta-data/placeme
 The sample relies on packer to build an AWS Machine Image (AMI) containing an installation of Gromacs.
 It is compiled and optimized for Intel Xeon Scalable Processor using the following compiler and MPI combination:
 
-- Intel oneAPI compiler and Intel oneAPI MPI 2021.3.0
+- Intel oneAPI compiler and Intel oneAPI MPI 2022.1.2
 - GNU 10.3.0 and Open MPI 4.1.0
 
 The packer scripts are located in the amis folder and are organized by Operating System (OS) such as `\[OS\]-pc-gromacs`.

--- a/apps/gromacs/performance/submit-gromacs-testA.sh
+++ b/apps/gromacs/performance/submit-gromacs-testA.sh
@@ -15,8 +15,7 @@ export I_MPI_OFI_PROVIDER=efa
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
 
 module purge
-module load compiler/intel/2021.3.0 mpi/intel/2021.3.0 gromacs/v2021.4-intel-2021.3.0
+module load compiler/intel/2022.1.2 mpi/intel/2022.1.2 gromacs/v2021.4-intel-2022.1.2
 
 cd Gromacs-TestCaseA
 mpirun gmx_mpi mdrun -ntomp $OMP_NUM_THREADS -s benchPEP.tpr -resethway
-

--- a/apps/gromacs/performance/submit-gromacs-testB.sh
+++ b/apps/gromacs/performance/submit-gromacs-testB.sh
@@ -15,7 +15,7 @@ export I_MPI_OFI_PROVIDER=efa
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
 
 module purge
-module load compiler/intel/2021.3.0 mpi/intel/2021.3.0 gromacs/v2021.4-intel-2021.3.0
+module load compiler/intel/2022.1.2 mpi/intel/2022.1.2 gromacs/v2021.4-intel-2022.1.2
 
 cd Gromacs-TestCaseB
 mpirun gmx_mpi mdrun -ntomp $OMP_NUM_THREADS -s benchRIB.tpr -resethway

--- a/apps/lammps/README.md
+++ b/apps/lammps/README.md
@@ -93,7 +93,7 @@ export AWS_REGION=`curl --silent http://169.254.169.254/latest/meta-data/placeme
 The sample relies on packer to build an AWS Machine Image (AMI) containing an installation of LAMMPS.
 It is compiled and optimized for Intel Xeon Scalable Processor using the following compiler and MPI combination:
 
-- Intel oneAPI compiler and Intel oneAPI MPI 2021.3.0
+- Intel oneAPI compiler and Intel oneAPI MPI 2022.1.2
 - GNU 10.3.0 and Open MPI 4.1.0
 
 The packer scripts are located in the amis folder and are organized by Operating System (OS) such as `\[OS\]-pc-lammps`.

--- a/apps/lammps/performance/slurm-c5n-intel-lj.sh
+++ b/apps/lammps/performance/slurm-c5n-intel-lj.sh
@@ -12,7 +12,7 @@ export I_MPI_OFI_LIBRARY_INTERNAL=0
 export I_MPI_OFI_PROVIDER=efa
 
 module purge
-module load compiler/intel/2021.3.0 mpi/intel/2021.3.0 lammps/stable_29Oct2020-intel-2021.3.0
+module load compiler/intel/2022.1.2 mpi/intel/2022.1.2 lammps/stable_29Oct2020-intel-2022.1.2
 
 
 WORK_DIR="/fsx/performance/$SLURM_JOB_NAME_$SLURM_JOB_ID"

--- a/apps/mpas/README.md
+++ b/apps/mpas/README.md
@@ -80,7 +80,7 @@ export AWS_REGION=`curl --silent http://169.254.169.254/latest/meta-data/placeme
 The sample relies on packer to build an AWS Machine Image (AMI) containing an installation of MPAS.
 It is compiled and optimized for Intel Xeon Scalable Processor using the following compiler and MPI combination:
 
-- Intel oneAPI compiler and Intel oneAPI MPI 2021.3.0
+- Intel oneAPI compiler and Intel oneAPI MPI 2022.1.2
 - GNU 10.3.0 and Open MPI 4.1.0
 
 The packer scripts are located in the amis folder and are organized by Operating System (OS) such as `\[OS\]-pc-mpas`.
@@ -176,7 +176,7 @@ export I_MPI_OFI_PROVIDER=efa
 
 module purge
 module load metis/5.1.0-gcc-10.3.0
-module load mpas-omp/7.1-intel-2021.3.0
+module load mpas-omp/7.1-intel-2022.1.2
 
 #Create mesh decomposition for the specified MPI ranks
 gpmetis -minconn -contig -niter=200 supercell.graph.info \${SLURM_NPROCS}

--- a/apps/wrf/README.md
+++ b/apps/wrf/README.md
@@ -85,7 +85,7 @@ export AWS_REGION=`curl --silent http://169.254.169.254/latest/meta-data/placeme
 The sample relies on packer to build an AWS Machine Image (AMI) containing an installation of WRF.
 It is compiled and optimized for Intel Xeon Scalable Processor using the following compiler and MPI combination:
 
-- Intel oneAPI compiler and Intel oneAPI MPI 2021.3.0
+- Intel oneAPI compiler and Intel oneAPI MPI 2022.1.2
 - GNU 10.3.0 and Open MPI 4.1.0
 
 The packer scripts are located in the amis folder and are organized by Operating System (OS) such as `\[OS\]-pc-wrf`.
@@ -209,7 +209,7 @@ export I_MPI_OFI_LIBRARY_INTERNAL=0
 export I_MPI_OFI_PROVIDER=efa
 
 module purge
-module load wrf-omp/4.2.2-intel-2021.3.0
+module load wrf-omp/4.2.2-intel-2022.1.2
 
 mpirun wrf.exe
 EOF

--- a/scripts/install/gromacs_install.sh
+++ b/scripts/install/gromacs_install.sh
@@ -54,7 +54,8 @@ done
 
 GROMACS_URL=https://gitlab.com/gromacs/gromacs.git
 MODULES_PATH="/usr/share/Modules/modulefiles"
-ENVIRONMENT="intel/2021.3.0;intel/2021.3.0 gcc/10.3.0;openmpi/4.1.0"
+ENVIRONMENT="intel/2022.1.2;intel/2022.1.2 gcc/10.3.0;openmpi/4.1.0"
+
 
 yum install -y \
     environment-modules \

--- a/scripts/install/hdf5_install.sh
+++ b/scripts/install/hdf5_install.sh
@@ -25,8 +25,7 @@ HDF5_URL="https://bitbucket.hdfgroup.org/scm/hdffv/hdf5.git"
 ZLIB_VERSION="1.2.11"
 ZLIB_PATH="/opt/zlib/${ZLIB_VERSION}"
 
-ENVIRONMENT="intel/2021.3.0;intel/2021.3.0 gcc/10.3.0;openmpi/4.1.0"
-
+ENVIRONMENT="intel/2022.1.2;intel/2022.1.2 gcc/10.3.0;openmpi/4.1.0"
 
 yum install -y \
     environment-modules \

--- a/scripts/install/intel_oneapi_compiler_mpi_install.sh
+++ b/scripts/install/intel_oneapi_compiler_mpi_install.sh
@@ -19,7 +19,7 @@ set -e
 
 MODULES_PATH="/usr/share/Modules/modulefiles"
 
-INTEL_VERSION="2021.3.0"
+INTEL_VERSION="2022.1.2"
 
 INTEL_PATH="/opt/intel/oneapi"
 

--- a/scripts/install/lammps_install.sh
+++ b/scripts/install/lammps_install.sh
@@ -54,9 +54,8 @@ done
 
 LAMMPS_URL=https://github.com/lammps/lammps.git
 MODULES_PATH="/usr/share/Modules/modulefiles"
-DEPENDS_ON="mkl/2021.3.0"
-ENVIRONMENT="intel/2021.3.0;intel/2021.3.0 gcc/10.3.0;openmpi/4.1.0"
-
+DEPENDS_ON="mkl/2022.0.2"
+ENVIRONMENT="intel/2022.1.2;intel/2022.1.2 gcc/10.3.0;openmpi/4.1.0"
 
 yum install -y \
     environment-modules \

--- a/scripts/install/mpas_install.sh
+++ b/scripts/install/mpas_install.sh
@@ -57,7 +57,7 @@ DEPENDS_ON="hdf5-parallel/1.10.6 pnetcdf/1.12.2 netcdf-c/4.7.4 netcdf-fortran/4.
 
 MPAS_URL="https://github.com/MPAS-Dev/MPAS-Model.git"
 
-ENVIRONMENT="intel/2021.3.0;intel/2021.3.0 gcc/10.3.0;openmpi/4.1.0"
+ENVIRONMENT="intel/2022.1.2;intel/2022.1.2 gcc/10.3.0;openmpi/4.1.0"
 
 yum install -y \
     environment-modules \

--- a/scripts/install/netcdf_c_install.sh
+++ b/scripts/install/netcdf_c_install.sh
@@ -25,8 +25,7 @@ DEPENDS_ON="hdf5-parallel/1.10.6 pnetcdf/1.12.2"
 NETCDF_C_ARCHIVE="netcdf-c-${NETCDF_C_VERSION}.tar.gz"
 NETCDF_C_URL="https://codeload.github.com/Unidata/netcdf-c/tar.gz/refs/tags/v${NETCDF_C_VERSION}"
 
-ENVIRONMENT="intel/2021.3.0;intel/2021.3.0 gcc/10.3.0;openmpi/4.1.0"
-
+ENVIRONMENT="intel/2022.1.2;intel/2022.1.2 gcc/10.3.0;openmpi/4.1.0"
 
 yum install -y \
     curl-devel \

--- a/scripts/install/netcdf_fortran_install.sh
+++ b/scripts/install/netcdf_fortran_install.sh
@@ -25,7 +25,7 @@ DEPENDS_ON="hdf5-parallel/1.10.6 netcdf-c/4.7.4"
 NETCDF_FORTRAN_ARCHIVE="netcdf-fortran-${NETCDF_FORTRAN_VERSION}.tar.gz"
 NETCDF_FORTRAN_URL="https://codeload.github.com/Unidata/netcdf-fortran/tar.gz/refs/tags/v${NETCDF_FORTRAN_VERSION}"
 
-ENVIRONMENT="intel/2021.3.0;intel/2021.3.0 gcc/10.3.0;openmpi/4.1.0"
+ENVIRONMENT="intel/2022.1.2;intel/2022.1.2 gcc/10.3.0;openmpi/4.1.0"
 
 yum install -y \
     curl-devel \

--- a/scripts/install/pio_install.sh
+++ b/scripts/install/pio_install.sh
@@ -28,7 +28,7 @@ PACKAGE_ARCHIVE="${PACKAGE_NAME}${PACKAGE_VERSION//./_}/${PACKAGE_NAME}-${PACKAG
 PACKAGE_TAR=$(echo $PACKAGE_ARCHIVE | cut -d'/' -f2)
 PACKAGE_URL="https://github.com/NCAR/ParallelIO/releases/download/${PACKAGE_ARCHIVE}"
 
-ENVIRONMENT="intel/2021.3.0;intel/2021.3.0 gcc/10.3.0;openmpi/4.1.0"
+ENVIRONMENT="intel/2022.1.2;intel/2022.1.2 gcc/10.3.0;openmpi/4.1.0"
 
 yum install -y \
     curl-devel \

--- a/scripts/install/pnetcdf_install.sh
+++ b/scripts/install/pnetcdf_install.sh
@@ -24,7 +24,7 @@ PNETCDF_VERSION="1.12.2"
 PNETCDF_ARCHIVE="pnetcdf-${PNETCDF_VERSION}.tar.gz"
 PNETCDF_URL="https://parallel-netcdf.github.io/Release/${PNETCDF_ARCHIVE}"
 
-ENVIRONMENT="intel/2021.3.0;intel/2021.3.0 gcc/10.3.0;openmpi/4.1.0"
+ENVIRONMENT="intel/2022.1.2;intel/2022.1.2 gcc/10.3.0;openmpi/4.1.0"
 
 yum install -y \
     environment-modules \

--- a/scripts/install/wrf_install.sh
+++ b/scripts/install/wrf_install.sh
@@ -57,7 +57,7 @@ DEPENDS_ON="hdf5-parallel/1.10.6 pnetcdf/1.12.2 netcdf-c/4.7.4 netcdf-fortran/4.
 
 WRF_URL="https://github.com/wrf-model/WRF.git"
 
-ENVIRONMENT="intel/2021.3.0;intel/2021.3.0 gcc/10.3.0;openmpi/4.1.0"
+ENVIRONMENT="intel/2022.1.2;intel/2022.1.2 gcc/10.3.0;openmpi/4.1.0"
 
 yum install -y \
     environment-modules \


### PR DESCRIPTION
Close #27

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
