### PR TITLE
Fix MKL version for Intel oneAPI 2022.2

### DIFF
--- a/scripts/install/lammps_install.sh
+++ b/scripts/install/lammps_install.sh
@@ -54,7 +54,7 @@ done
 
 LAMMPS_URL=https://github.com/lammps/lammps.git
 MODULES_PATH="/usr/share/Modules/modulefiles"
-DEPENDS_ON="mkl/2022.0.2"
+DEPENDS_ON="mkl/2022.1.0"
 ENVIRONMENT="intel/2022.2.0;intel/2022.2.0 gcc/10.3.0;openmpi/4.1.0"
 
 yum install -y \


### PR DESCRIPTION
Fixing the MKL version number.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
