### PR TITLE
Change AWS ParallelCluster default version to 3.4.1

### DIFF
--- a/apps/gromacs/README.md
+++ b/apps/gromacs/README.md
@@ -79,7 +79,7 @@ source .env/bin/activate
 Install AWS ParallelCluster
 
 ```bash
-pip3 install aws-parallelcluster==3.2.0
+pip3 install aws-parallelcluster==3.4.1
 
 # Set AWS Region
 export AWS_REGION=`curl --silent http://169.254.169.254/latest/meta-data/placement/region`

--- a/apps/gromacs/amis/amzn2-pc-gromacs/variables.json
+++ b/apps/gromacs/amis/amzn2-pc-gromacs/variables.json
@@ -1,6 +1,6 @@
 {
   "aws_region": "us-east-1",
-  "parallel_cluster_version": "3.2.0",
+  "parallel_cluster_version": "3.4.1",
   "application_name": "gromacs",
   "application_version": "v2021.4",
   "intel_serial_number": "",

--- a/apps/gromacs/docs/packer_ami_variables.md
+++ b/apps/gromacs/docs/packer_ami_variables.md
@@ -18,7 +18,7 @@ Here is a description of the variables and their default value:
 | name                       | Name used as AMI name in the middle              | String  | \[OS\]-parallelcluster | no       |
 | instance\_type             | EC2 instance type                                | String  | m5zn.3xlarge           | no       |
 | intel\_serial\_number      | Intel license serial number                      | String  | None                   | no       |
-| parallel\_cluster\_version | ParallelCluster version to base AMI from         | String  | 3.2.0                  | no       |
+| parallel\_cluster\_version | ParallelCluster version to base AMI from         | String  | 3.4.1                  | no       |
 | public\_ip                 | Assign an elastic public IP                      | Boolean | True                   | no       |
 | ssh\_interface             | SSH interface either SSH or Session Manager      | String  | session\_manager       | no       |
 | state                      | AMI state: active, deprecated, obsolete          | String  | active                 | no       |

--- a/apps/lammps/README.md
+++ b/apps/lammps/README.md
@@ -78,7 +78,7 @@ source .env/bin/activate
 Install AWS ParallelCluster
 
 ```bash
-pip3 install aws-parallelcluster==3.2.0
+pip3 install aws-parallelcluster==3.4.1
 ```
 
 Set AWS Region

--- a/apps/lammps/amis/amzn2-pc-lammps/variables.json
+++ b/apps/lammps/amis/amzn2-pc-lammps/variables.json
@@ -1,6 +1,6 @@
 {
   "aws_region": "us-east-1",
-  "parallel_cluster_version": "3.2.0",
+  "parallel_cluster_version": "3.4.1",
   "application_name": "lammps",
   "application_version": "stable_29Oct2020",
   "intel_serial_number": "",

--- a/apps/lammps/docs/packer_ami_variables.md
+++ b/apps/lammps/docs/packer_ami_variables.md
@@ -18,7 +18,7 @@ Here is a description of the variables and their default value:
 | name                       | Name used as AMI name in the middle              | String  | \[OS\]-parallelcluster | no       |
 | instance\_type             | EC2 instance type                                | String  | m5zn.3xlarge           | no       |
 | intel\_serial\_number      | Intel license serial number                      | String  | None                   | no       |
-| parallel\_cluster\_version | ParallelCluster version to base AMI from         | String  | 3.2.0                  | no       |
+| parallel\_cluster\_version | ParallelCluster version to base AMI from         | String  | 3.4.1                  | no       |
 | public\_ip                 | Assign an elastic public IP                      | Boolean | True                   | no       |
 | ssh\_interface             | SSH interface either SSH or Session Manager      | String  | session\_manager       | no       |
 | state                      | AMI state: active, deprecated, obsolete          | String  | active                 | no       |

--- a/apps/mpas/README.md
+++ b/apps/mpas/README.md
@@ -69,7 +69,7 @@ source .env/bin/activate
 Install AWS ParallelCluster
 
 ```bash
-pip3 install aws-parallelcluster==3.2.0
+pip3 install aws-parallelcluster==3.4.1
 
 # Set AWS Region
 export AWS_REGION=`curl --silent http://169.254.169.254/latest/meta-data/placement/region`

--- a/apps/mpas/amis/amzn2-pc-mpas/variables.json
+++ b/apps/mpas/amis/amzn2-pc-mpas/variables.json
@@ -1,6 +1,6 @@
 {
   "aws_region": "us-east-1",
-  "parallel_cluster_version": "3.2.0",
+  "parallel_cluster_version": "3.4.1",
   "application_name": "mpas",
   "application_version": "7.1",
   "intel_serial_number": "",

--- a/apps/mpas/docs/packer_ami_variables.md
+++ b/apps/mpas/docs/packer_ami_variables.md
@@ -18,7 +18,7 @@ Here is a description of the variables and their default value:
 | name                       | Name used as AMI name in the middle              | String  | \[OS\]-base      | no       |
 | instance\_type             | EC2 instance type                                | String  | m5zn.3xlarge     | no       |
 | intel\_serial\_number      | Intel license serial number                      | String  | None             | no       |
-| parallel\_cluster\_version | ParallelCluster version to base AMI from         | String  | 3.2.0            | no       |
+| parallel\_cluster\_version | ParallelCluster version to base AMI from         | String  | 3.4.1            | no       |
 | public\_ip                 | Assign an elastic public IP                      | Boolean | True             | no       |
 | ssh\_interface             | SSH interface either SSH or Session Manager      | String  | session\_manager | no       |
 | state                      | AMI state: active, deprecated, obsolete          | String  | active           | no       |

--- a/apps/openfoam/README.md
+++ b/apps/openfoam/README.md
@@ -68,7 +68,7 @@ source .env/bin/activate
 Install AWS ParallelCluster
 
 ```bash
-pip3 install aws-parallelcluster==3.2.0
+pip3 install aws-parallelcluster==3.4.1
 ```
 
 Set AWS Region

--- a/apps/openfoam/amis/amzn2-pc-openfoam/variables.json
+++ b/apps/openfoam/amis/amzn2-pc-openfoam/variables.json
@@ -1,6 +1,6 @@
 {
   "aws_region": "us-east-1",
-  "parallel_cluster_version": "3.2.0",
+  "parallel_cluster_version": "3.4.1",
   "application_name": "openfoam",
   "application_version": "2012",
   "intel_serial_number": "",

--- a/apps/openfoam/amis/centos7-pc-openfoam/variables.json
+++ b/apps/openfoam/amis/centos7-pc-openfoam/variables.json
@@ -1,6 +1,6 @@
 {
   "aws_region": "us-east-1",
-  "parallel_cluster_version": "3.2.0",
+  "parallel_cluster_version": "3.4.1",
   "application_name": "openfoam",
   "application_version": "2012",
   "intel_serial_number": "",

--- a/apps/openfoam/docs/packer_ami_variables.md
+++ b/apps/openfoam/docs/packer_ami_variables.md
@@ -18,7 +18,7 @@ Here is a description of the variables and their default value:
 | name                       | Name used as AMI name in the middle              | String  | \[OS\]-parallelcluster | no       |
 | instance\_type             | EC2 instance type                                | String  | m5zn.3xlarge           | no       |
 | intel\_serial\_number      | Intel license serial number                      | String  | None                   | no       |
-| parallel\_cluster\_version | ParallelCluster version to base AMI from         | String  | 3.2.0                  | no       |
+| parallel\_cluster\_version | ParallelCluster version to base AMI from         | String  | 3.4.1                  | no       |
 | public\_ip                 | Assign an elastic public IP                      | Boolean | True                   | no       |
 | ssh\_interface             | SSH interface either SSH or Session Manager      | String  | session\_manager       | no       |
 | state                      | AMI state: active, deprecated, obsolete          | String  | active                 | no       |

--- a/apps/wrf/README.md
+++ b/apps/wrf/README.md
@@ -72,7 +72,7 @@ source .env/bin/activate
 Install AWS ParallelCluster
 
 ```bash
-pip3 install aws-parallelcluster==3.2.0
+pip3 install aws-parallelcluster==3.4.1
 ```
 
 Set AWS Region

--- a/apps/wrf/amis/amzn2-pc-wrf/variables.json
+++ b/apps/wrf/amis/amzn2-pc-wrf/variables.json
@@ -1,6 +1,6 @@
 {
   "aws_region": "us-east-1",
-  "parallel_cluster_version": "3.2.0",
+  "parallel_cluster_version": "3.4.1",
   "application_name": "wrf",
   "application_version": "4.2.2",
   "intel_serial_number": "",

--- a/apps/wrf/docs/packer_ami_variables.md
+++ b/apps/wrf/docs/packer_ami_variables.md
@@ -18,7 +18,7 @@ Here is a description of the variables and their default value:
 | name                       | Name used as AMI name in the middle              | String  | \[OS\]-base      | no       |
 | instance\_type             | EC2 instance type                                | String  | m5zn.3xlarge     | no       |
 | intel\_serial\_number      | Intel license serial number                      | String  | None             | no       |
-| parallel\_cluster\_version | ParallelCluster version to base AMI from         | String  | 3.2.0            | no       |
+| parallel\_cluster\_version | ParallelCluster version to base AMI from         | String  | 3.4.1            | no       |
 | public\_ip                 | Assign an elastic public IP                      | Boolean | True             | no       |
 | ssh\_interface             | SSH interface either SSH or Session Manager      | String  | session\_manager | no       |
 | state                      | AMI state: active, deprecated, obsolete          | String  | active           | no       |


### PR DESCRIPTION
Close #93

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
