### PR TITLE
Fix issue 107 - install both gmx and gmx_mpi gromacs binaries

### DIFF
--- a/scripts/install/gromacs_install.sh
+++ b/scripts/install/gromacs_install.sh
@@ -111,8 +111,24 @@ do
     mkdir -p build
     cd build
 
-
     echo "Compiling GROMACS code"
+    cmake3 .. \
+        -DGMX_BUILD_OWN_FFTW=ON \
+        -DREGRESSIONTEST_DOWNLOAD=OFF \
+        -DCMAKE_C_COMPILER=mpicc \
+        -DCMAKE_CXX_COMPILER=mpicxx \
+        -DGMX_MPI=OFF \
+        -DGMX_OPENMP=on \
+        -DGMX_DOUBLE=OFF \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DGMXAPI=OFF \
+        -DCMAKE_INSTALL_PREFIX=${GROMACS_PATH} \
+        -DGMX_SIMD=AVX_512
+
+    make -j
+    make install
+
+    echo "Compiling GROMACS MPI code"
     cmake3 .. \
         -DGMX_BUILD_OWN_FFTW=ON \
         -DREGRESSIONTEST_DOWNLOAD=OFF \


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/awsome-hpc/issues/107#issue-1603452731

*Description of changes:*
Configure gromacs build once with DGMX_MPI=OFF and once with GDMX_MPI=on. Make and install both to include both gmx and gmx_mpi binaries in gromacs setup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
